### PR TITLE
Precompiled

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ platforms:
       box: opensuse-12.3-64
       box_url: http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download
       require_chef_omnibus: true
-  - name: centos-6.5
+  - name: centos-6.7
   - name: fedora-20
   - name: debian-7.6
   - name: ubuntu-14.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@ This file is used to list changes made in each version of the rvm_fw cookbook.
 -----
 - [Steven Haddox] - Initial release of rvm_fw
 
-0.5.0
+0.2.0
 
 - [Brian Tavener] Added the option to download and use pre-compiled rubies  from an external url (tar.gz format only) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ This file is used to list changes made in each version of the rvm_fw cookbook.
 0.1.0
 -----
 - [Steven Haddox] - Initial release of rvm_fw
+
+0.5.0
+
+- [Brian Tavener] Added the option to download and use pre-compiled rubies  from an external url (tar.gz format only) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@ This file is used to list changes made in each version of the rvm_fw cookbook.
 -----
 - [Steven Haddox] - Initial release of rvm_fw
 
-0.2.0
+0.5.0
 
 - [Brian Tavener] Added the option to download and use pre-compiled rubies  from an external url (tar.gz format only) 

--- a/README.md
+++ b/README.md
@@ -63,15 +63,18 @@ And are available for the following commands:
 
 The attribute `['rvm_fw']['use_precompile?']` can be set to "true" to enable the downloading and installation of a prepackaged .rvm file.
 It downloads and extracts a tar.gz file.
-The user must specify a source url to download from by setting the `['rvm_fw']['pre_compiled_src_url']` attribute to a vaild url.
-Do not include any trailing "/"s
-(Example):
-   `'http://example.com/directory/directory'`
 
-The user must also specify a name for the source file by setting the `['rvm_fw']['compiled_file']` attribute
-Do not include the `.tar.gz` extension  in the name
-(Example):
-   `'example-file-name'`
+The user must specify a source url to download from by setting the `['rvm_fw']['pre_compiled_src_url']` attribute to a vaild url.
+
+Do not include any trailing "/"s.
+
+(Example): `'http://example.com/directory/directory'`
+
+The user must also specify a name for the source file by setting the `['rvm_fw']['compiled_file']` attribute.
+
+Do not include the `.tar.gz` extension  in the name.
+
+(Example): `'example-file-name'`
 
 #### RHEL Distros & `requiretty`
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ And are available for the following commands:
 * erb
 * testrb
 
+#### Using precompiled rubies
+
+The attribute "['rvm_fw']['use_precompile?']" can be set to "true" to enable the downloading and installation of a prepackaged .rvm file.
+It downloads and extracts a tar.gz file.
+The user must specify a source url to download from by setting the "['rvm_fw']['pre_compiled_src_url']" attribute to a vaild url.
+Do not include any trailing "/"s
+(Example):
+   'http://example.com/directory/directory'
+
+The user must also specify a name for the source file by setting the "['rvm_fw']['compiled_file']" attribute
+Do not include the ".tar.gz" extension  in the name
+(Example):
+   'example-file-name'
+
 #### RHEL Distros & `requiretty`
 
 In older (and SELinux enabled) distributions based on RHEL you'll often encounter a setting in `/etc/sudoers` that sets `Defaults requiretty`. This setting doesn't provide a lot of added security and is actually disabled in most newer distros.

--- a/README.md
+++ b/README.md
@@ -59,19 +59,19 @@ And are available for the following commands:
 * erb
 * testrb
 
-#### Using precompiled rubies
+#### Using Precompiled Rubies
 
-The attribute "['rvm_fw']['use_precompile?']" can be set to "true" to enable the downloading and installation of a prepackaged .rvm file.
+The attribute `['rvm_fw']['use_precompile?']` can be set to "true" to enable the downloading and installation of a prepackaged .rvm file.
 It downloads and extracts a tar.gz file.
-The user must specify a source url to download from by setting the "['rvm_fw']['pre_compiled_src_url']" attribute to a vaild url.
+The user must specify a source url to download from by setting the `['rvm_fw']['pre_compiled_src_url']` attribute to a vaild url.
 Do not include any trailing "/"s
 (Example):
-   'http://example.com/directory/directory'
+   `'http://example.com/directory/directory'`
 
-The user must also specify a name for the source file by setting the "['rvm_fw']['compiled_file']" attribute
-Do not include the ".tar.gz" extension  in the name
+The user must also specify a name for the source file by setting the `['rvm_fw']['compiled_file']` attribute
+Do not include the `.tar.gz` extension  in the name
 (Example):
-   'example-file-name'
+   `'example-file-name'`
 
 #### RHEL Distros & `requiretty`
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,3 +4,7 @@ default['rvm_fw']['global_ruby'] = 'ruby-2.2.3'
 default['rvm_fw']['extra_rubies'] = []
 default['rvm_fw']['disable_requiretty'] = false
 default['rvm_fw']['user'] = 'root'
+
+default['rvm_fw']['use_precompile?'] = false
+default['rvm_fw']['pre_compiled_src_url'] = ''
+default['rvm_fw']['compiled_file'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs common ruby packages and RVM via RVM::FW'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/stevenhaddox/cookbook-rvm_fw'
 issues_url 'https://github.com/stevenhaddox/cookbook-rvm_fw/issues'
-version '0.4.1'
+version '0.5.0'
 
 recipe 'rvm_fw::default', 'Install RVM via RVM::FW server'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,7 @@
 include_recipe 'apt' if node['platform_family'] == 'debian'
 #TODO include_recipe 'yum-epel' if %w(rhel fedora).include?(node['platform_family'])
 include_recipe 'build-essential'
+
 require 'chef/mixin/shell_out'
 Chef::Recipe.send(:include, ::Chef::Mixin::ShellOut)
 Chef::Resource.send(:include, ::Chef::Mixin::ShellOut)
@@ -20,8 +21,13 @@ if rvm_user == 'root'
 else
   rvm_path = "/home/#{rvm_user}/.rvm"
 end
+
 # node['rvm_fw']['path'] overrides above default paths
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
+
+#Attempt to download a precompiled version of the .rvm folder and its rubies
+include_recipe 'rvm_fw::extract_precompiled_ruby' if
+node['rvm_fw']['use_precompile?'] == true
 
 potentially_at_compile_time do
   # Pre-install packages to ensure RVM Rubies can compile against them

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ end
 # node['rvm_fw']['path'] overrides above default paths
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
 
-#Attempt to download a precompiled version of the .rvm folder and its rubies
+# Attempt to download a precompiled version of the .rvm folder and its rubies
 if node['rvm_fw']['use_precompile?'] == true
   include_recipe 'rvm_fw::extract_precompiled_ruby'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,8 +26,9 @@ end
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
 
 #Attempt to download a precompiled version of the .rvm folder and its rubies
-include_recipe 'rvm_fw::extract_precompiled_ruby' if
-node['rvm_fw']['use_precompile?'] == true
+if node['rvm_fw']['use_precompile?'] == true
+  include_recipe 'rvm_fw::extract_precompiled_ruby'
+end
 
 potentially_at_compile_time do
   # Pre-install packages to ensure RVM Rubies can compile against them

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -35,5 +35,5 @@ execute 'remap_rvm_directory' do
     mv -f .rvm rvm
     chown #{rvm_user}:#{rvm_user} -R rvm
   EOH
-  not_if do rvm_path == "/home/#{rvm_user}/.rvm" end
+  only_if do rvm_path == '/usr/local/rvm' end
 end

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -1,11 +1,11 @@
 rvm_user = node['rvm_fw']['user']
 if rvm_user == 'root'
   rvm_path = '/usr/local/rvm'
-  rvm_parent_path =  '/usr/local/'
 else
   rvm_path = "/home/#{rvm_user}/.rvm"
-  rvm_parent_path =  "/home/#{rvm_user}/"
 end
+
+rvm_parent_path =  ".. #{rvm_path}"
 
 # node['rvm_fw']['path'] overrides above default paths
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -7,6 +7,9 @@ else
   rvm_parent_path =  "/home/#{rvm_user}/"
 end
 
+# node['rvm_fw']['path'] overrides above default paths
+rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
+
 # Download the tar file from the web server
 remote_file "#{rvm_parent_path}#{node['rvm_fw']['compiled_file']}.tar.gz" do
   source "#{node['rvm_fw']['pre_compiled_src_url']}/#{node['rvm_fw']['compiled_file']}.tar.gz"

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -8,10 +8,10 @@ end
 # node['rvm_fw']['path'] overrides above default paths
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
 
-rvm_parent_path =  ".. #{rvm_path}"
+rvm_parent_path = File.dirname("#{rvm_path}")
 
 # Download the tar file from the web server
-remote_file "#{rvm_parent_path}#{node['rvm_fw']['compiled_file']}.tar.gz" do
+remote_file "#{rvm_parent_path}/#{node['rvm_fw']['compiled_file']}.tar.gz" do
   source "#{node['rvm_fw']['pre_compiled_src_url']}/#{node['rvm_fw']['compiled_file']}.tar.gz"
   owner "#{rvm_user}"
   group "#{rvm_user}"

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -7,18 +7,17 @@ else
   rvm_parent_path =  "/home/#{rvm_user}/"
 end
 
-#download the tar file from the web server
+# Download the tar file from the web server
 remote_file "#{rvm_parent_path}#{node['rvm_fw']['compiled_file']}.tar.gz" do
   source "#{node['rvm_fw']['pre_compiled_src_url']}/#{node['rvm_fw']['compiled_file']}.tar.gz"
   owner "#{rvm_user}"
   group "#{rvm_user}"
   mode '0775'
-#  notifies :run, 'execute[unpack_rvm_tar]', :immediately
   action :create
   not_if do ::File.exists?("#{rvm_path}") end
 end
 
-# unpack the tar  and ensure proper permissions
+# Unpack the tar and ensure proper permissions
 execute 'unpack_rvm_tar' do
   command <<-EOH
   cd #{rvm_parent_path}
@@ -29,12 +28,12 @@ execute 'unpack_rvm_tar' do
   not_if do ::File.exists?("#{rvm_path}") end
 end
 
-#the root installs to a different folder , if root is the user  move the folder
+# The root installs to a different folder , if root is the user  move the folder
 execute 'remap_rvm_directory' do
-command <<-EOH
-cd #{rvm_parent_path}
-  mv -f .rvm rvm
-  chown #{rvm_user}:#{rvm_user} -R rvm
-EOH
-  not_if do rvm_path == "/home/#{rvm_user}/.rvm" end # add and  file exists?
+  command <<-EOH
+  cd #{rvm_parent_path}
+    mv -f .rvm rvm
+    chown #{rvm_user}:#{rvm_user} -R rvm
+  EOH
+  not_if do rvm_path == "/home/#{rvm_user}/.rvm" end
 end

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -1,0 +1,29 @@
+#download the tar file from the web server
+remote_file "/home/#{rvm_user}/#{node['rvm_fw']['compiled_file']}.tar.gz" do
+  source "#{node['rvm_fw']['pre_compiled_src_url']}/#{node['rvm_fw']['compiled_file']}.tar.gz"
+  owner "#{rvm_user}"
+  group "#{rvm_user}"
+  mode '0775'
+  notifies :run, 'execute[unpack_rvm_tar]', :immediately
+  action :create
+  not_if do ::File.exists?("#{rvm_path}") end
+end
+
+# unpack the tar  and ensure proper permissions
+execute 'unpack_rvm_tar' do
+  command <<-EOH
+    cd /home/#{rvm_user}/
+    tar zxf #{node['rvm_fw']['compiled_file']}.tar.gz
+    if [#{rvm_path} = "/usr/local/rvm"]; then
+      mv .rvm rvm
+      chown #{rvm_user}:#{rvm_user} -R rvm
+    else
+      chown #{rvm_user}:#{rvm_user} -R .rvm
+    fi
+    rm #{node['rvm_fw']['compiled_file']}.tar.gz
+  EOH
+  not_if do ::File.exists?("#{rvm_path}") end
+  action :nothing
+endd
+
+

--- a/recipes/extract_precompiled_ruby.rb
+++ b/recipes/extract_precompiled_ruby.rb
@@ -5,10 +5,10 @@ else
   rvm_path = "/home/#{rvm_user}/.rvm"
 end
 
-rvm_parent_path =  ".. #{rvm_path}"
-
 # node['rvm_fw']['path'] overrides above default paths
 rvm_path = node['rvm_fw']['path'] unless node['rvm_fw']['path'].nil?
+
+rvm_parent_path =  ".. #{rvm_path}"
 
 # Download the tar file from the web server
 remote_file "#{rvm_parent_path}#{node['rvm_fw']['compiled_file']}.tar.gz" do


### PR DESCRIPTION
I have added the following to your readme as well
#### Using precompiled rubies

The attribute "['rvm_fw']['use_precompile?']" can be set to "true" to enable the downloading and installation of a prepackaged .rvm file.
It downloads and extracts a tar.gz file.
The user must specify a source url to download from by setting the "['rvm_fw']['pre_compiled_src_url']" attribute to a vaild url.
Do not include any trailing "/"s
(Example):
   'http://example.com/directory/directory'

The user must also specify a name for the source file by setting the "['rvm_fw']['compiled_file']" attribute
Do not include the ".tar.gz" extension  in the name
(Example):
   'example-file-name'
